### PR TITLE
add dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Simple python (tkinter) based gui for ROS install process
 The installer process for [ROS](http://www.ros.org) in a simple gui.
 
 Dependency: python 2, and tkinter
-```sudo apt-get install python-tk```
+```sudo apt-get install python-tk python-imaging-tk```
 
 Simply run ``` python tkmain.py``` as a user who is able to run sudo commands.
 Do not run as root or directly with ```sudo``` as it will otherwise write the wrong shell configuration files and it is not recommended to run ```rosdep update``` as root.


### PR DESCRIPTION
At least on my Ubuntu 14.04.3 box, I had to install `python-imaging-tk` to make this run. Perhaps installing `python-imaging-tk` is all that people need to do, since presumably that will bring in `python-tk` as well (?)
